### PR TITLE
Add setting to buildLoginUrl so it can omit port number in url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,4 @@ FakesAssemblies/
 .vagrant/
 nupkg/
 _*.nuspec
+/.vscode

--- a/samples/netcore/Program.fs
+++ b/samples/netcore/Program.fs
@@ -66,7 +66,7 @@ let main _ =
             path "/" >=> page "main.html" model
 
             warbler(fun ctx ->
-                let authorizeRedirectUri = buildLoginUrl ctx in
+                let authorizeRedirectUri = buildLoginUrl(ctx, false) in
                 // Note: logon state for current user is stored in global variable, which is ok for demo purposes.
                 // in your application you shoud store such kind of data to session data
                 OAuth.authorize authorizeRedirectUri oauthConfigs

--- a/src/OAuth.fs
+++ b/src/OAuth.fs
@@ -225,13 +225,17 @@ let processLogin (configs: Map<string,ProviderConfig>) redirectUri (fnSuccess: L
 /// Provided for demo purposes as it cannot handle more complicated scenarios involving proxy, docker, azure etc.
 /// </summary>
 /// <param name="ctx"></param>
-let buildLoginUrl (ctx:HttpContext) =
-    let buildr = System.UriBuilder ctx.request.url
-    buildr.Host <- ctx.request.host
-    buildr.Path <- "oalogin"
-    buildr.Query <- ""
+/// <param name="omitPort"></param>
+let buildLoginUrl (ctx: HttpContext, omitPort: bool) =
+    let bb = System.UriBuilder (ctx.request.url)
+    bb.Host <- ctx.request.host
+    bb.Path <- "oalogin"
+    match omitPort with
+    | true -> bb.Port <- -1
+    | _ -> ()
+    bb.Query <- ""
 
-    buildr.ToString()
+    bb.ToString()
 
 /// <summary>
 /// Handles OAuth authorization requests. Stores auth info in session cookie


### PR DESCRIPTION
Retry of pull request "Change buildLogUrl so it can omit port number, for use on Azure"